### PR TITLE
Fix meta.yaml logic for autotick-bot compatibility

### DIFF
--- a/.ci_support/migrations/tinyxml2-9.yaml
+++ b/.ci_support/migrations/tinyxml2-9.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-tinyxml2:
-- 9
-migrator_ts: 1624484606

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,19 +1,20 @@
 {% set component_name = "launch" %}
 {% set base_name = "libignition-" + component_name %}
-{% set version = "4.0.0" %}
-{% set major_version = version.split('.')[0] %}
+{% set version = "4_4.0.0" %}
+{% set version_package = version.split('_')[1] %}
+{% set major_version = version.split('_')[0] %}
 {% set name = base_name + major_version %}
 
 package:
   name: {{ name }}
-  version: {{ version }}
+  version: {{ version_package }}
 
 source:
-  - url: https://github.com/ignitionrobotics/ign-{{ component_name }}/archive/ignition-{{ component_name }}{{ major_version }}_{{ version }}.tar.gz
+  - url: https://github.com/ignitionrobotics/ign-{{ component_name }}/archive/ignition-{{ component_name }}{{ version }}.tar.gz
     sha256: e2e71bc96630b46663dfa8d12dd7d2dd8f2573ad893f608f6c5c2c08bd39c896
 
 build:
-  number: 1
+  number: 2
   skip: true  # [not linux]
   run_exports:
     - {{ pin_subpackage(name, max_pin='x') }}


### PR DESCRIPTION
This PR changes the definition of the `version` variable to match the format used in the tags, i.e. `4_4.1.0`, so that the autotick-bot (that extracts the version information from git tags by stripping all the characters till the first digit) works fine. The version in `4.1.0` format is now contained in the `version_package` variable (see https://github.com/conda-forge/libignition-msgs1-feedstock/issues/50 and https://github.com/conda-forge/libignition-msgs1-feedstock/issues/53 ).

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
